### PR TITLE
K8S Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 .idea/
+.history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine 
+COPY docs/* /usr/share/nginx/html/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ yarn start
 http://localhost:3000/
 ```
 
+## K8S Deployment
+
+1. `docker build -t quay.io/geotrellis/azavea-tech-radar:latest .`
+    * `docker push quay.io/geotrellis/azavea-tech-radar:latest`
+2. `kubectl apply -f manifests/tech-radar.yaml`
+
 ## Adding a new entry
 
 If all you want to do is add a new entry, you'll need to create a javascript object like:

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@
       },
       {
         quadrant: 1,
-        ring: 2,
+        ring: 1,
         label: "Kubernetes",
         active: false,
         link: null,

--- a/manifests/tech-radar.yaml
+++ b/manifests/tech-radar.yaml
@@ -1,0 +1,29 @@
+# create tech-radar namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tech-radar
+  labels:
+    name: tech-radar
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tech-radar-deployment
+  namespace: tech-radar
+spec:
+  selector:
+    matchLabels:
+      app: tech-radar
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tech-radar
+    spec:
+      containers:
+      - name: tech-radar
+        image: quay.io/geotrellis/azavea-tech-radar:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80

--- a/manifests/tech-radar.yaml
+++ b/manifests/tech-radar.yaml
@@ -24,6 +24,6 @@ spec:
       containers:
       - name: tech-radar
         image: quay.io/geotrellis/azavea-tech-radar:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 80


### PR DESCRIPTION
This PR adds K8S Deployment manifest. 
I used `quay.io/geotrellis` org since I don't have access to `quay.io/azavea` at the moment.